### PR TITLE
Fix Italian homepage buttons

### DIFF
--- a/config/_default/languages/.it.toml
+++ b/config/_default/languages/.it.toml
@@ -27,9 +27,9 @@ Qui c'è la [pagina github del tema](https://github.com/ololiuhqui/magnolia-free
 Guardate cosa è in grado di fare questo tema nella pagina delle caratteristiche e vedete un bellissimo esempio di pagina dei contatti qui sotto.
         """
     mainButton = "Caratteristiche"
-    mainButtonRef = "caratteristiche"
+    mainButtonRef = "/caratteristiche"
     secondButton = "Contatti"
-    secondButtonRef = "contatti" 
+    secondButtonRef = "/contatti" 
     
     blogTitle = "Storie interessanti"
     blogButton= "More Stories"


### PR DESCRIPTION
The **Caratteristiche** and **Contatti** buttons on the [Italian version of the homepage](https://ololiuhqui.github.io/magnolia-free-hugo-theme/it/) (`/it`) currently use relative URLs (e.g. `caratteristiche`) rather than absolute URLs (`/caratteristiche`), resulting in a 404 error.

This PR fixes those buttons, ensuring the links point to the correct URLs.