### PR TITLE
Add license name to LICENSE.md (main)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,6 @@
-Copyright 2024 Ludovico Caluori
+MIT License
+
+Copyright (c) 2024 Ludovico Caluori
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
Minor tweak: Added `MIT License` to `LICENSE.md` so the license is more clearly recognizable when working on a local copy.