### PR TITLE
feat: add option to block AI crawlers via robots.txt

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -3,3 +3,60 @@ User-agent: *
 Disallow: /{{ . }}/404
 {{end}}
 Sitemap: {{$.Site.BaseURL}}/sitemap.xml
+{{ if .Site.Params.robots.blockAIcrawlers }}
+# Block all known AI crawlers and assistants
+# from using content for training AI models.
+# Source: https://robotstxt.com/ai
+User-Agent: GPTBot
+User-Agent: ClaudeBot
+User-Agent: Claude-Web
+User-Agent: CCBot
+User-Agent: Googlebot-Extended
+User-Agent: Applebot-Extended
+User-Agent: Facebookbot
+User-Agent: Meta-ExternalAgent
+User-Agent: Meta-ExternalFetcher
+User-Agent: diffbot
+User-Agent: PerplexityBot
+User-Agent: Omgili
+User-Agent: Omgilibot
+User-Agent: webzio-extended
+User-Agent: ImagesiftBot
+User-Agent: Bytespider
+User-Agent: Amazonbot
+User-Agent: Youbot
+User-Agent: SemrushBot-OCOB
+User-Agent: Petalbot
+User-Agent: VelenPublicWebCrawler
+User-Agent: TurnitinBot
+User-Agent: Timpibot
+User-Agent: OAI-SearchBot
+User-Agent: ICC-Crawler
+User-Agent: AI2Bot
+User-Agent: AI2Bot-Dolma
+User-Agent: DataForSeoBot
+User-Agent: AwarioBot
+User-Agent: AwarioSmartBot
+User-Agent: AwarioRssBot
+User-Agent: Google-CloudVertexBot
+User-Agent: PanguBot
+User-Agent: Kangaroo Bot
+User-Agent: Sentibot
+User-Agent: img2dataset
+User-Agent: Meltwater
+User-Agent: Seekr
+User-Agent: peer39_crawler
+User-Agent: cohere-ai
+User-Agent: cohere-training-data-crawler
+User-Agent: DuckAssistBot
+User-Agent: Scrapy
+Disallow: /
+DisallowAITraining: /
+
+# Block any non-specified AI crawlers (e.g., new
+# or unknown bots) from using content for training
+# AI models.  This directive is still experimental
+# and may not be supported by all AI crawlers.
+User-Agent: *
+DisallowAITraining: /
+{{ end }}


### PR DESCRIPTION
### Preamble

Thanks for the wonderful theme! :white_flower:

I plan on using it for a small business website of a friend of mine. I'll make sure to set up recurring donations via Liberapay once the website goes live to reward your efforts.

While adapting the theme for my needs, I implemented a few features and fixed some small things here and there. For those relevant for other users, I'll open up pull requests, so that you can selectively decide which ones you wish to merge :v:

Feel free to close those that do not seem relevant to you or let me know in case something should be adapted. Some require changes for the exampleSite as well. In those cases I have to open separate PRs and will link to the feature change PRs in the PR's description.

### Feature Description

Since AI/LLM crawlers are currently breaking the web as we know it, by sending loads and loads of requests even to small websites, I have also seen network traffic to my servers increase in recent months.
To at least curb that somewhat, I have opted for adding blocklists for AI crawlers and scrapers. OpenAI et al. apparently do not always adhere to those, but at least it should help somewhat.

This option makes it possible to add these with ease for any website that uses your theme by simply enabling it.