### PR TITLE
fix: center schedule div horizontally on contacts page

### DIFF
--- a/layouts/pages/contacts.html
+++ b/layouts/pages/contacts.html
@@ -137,7 +137,7 @@
     {{ if .Site.Params.schedules.enabledContacts}}
     <div class="col-lg-4 mb-3">
       <div class="card h-100 p-4 shadow-sm">
-        <div class="card-body text-center d-flex align-items-around">
+        <div class="card-body text-center d-flex align-items-around justify-content-center">
           <div class="row">
             <div class="col-12">
               <i class="display-4 bi-clock text-muted"></i>


### PR DESCRIPTION
### Fix description

The schedule is currently not centered horizontally in its `<div>` which looks kinda bad on mobile.