### PR TITLE
fix: do not display social icons if not enabled

### DIFF
--- a/layouts/pages/contacts.html
+++ b/layouts/pages/contacts.html
@@ -157,11 +157,9 @@
       </div>
     </div>
     {{end}}
-
-    <!-- /.row-->
-
-    <!-- /.row-->
   </div>
+
+  {{ if .Site.Params.socials.enabled }}
   <div class="row justify-content-center">
     <div class="col-lg-8">
       <p class="text-center text-muted mb-4">
@@ -178,5 +176,6 @@
     </div>
     {{ end}}
   </div>
+  {{ end }}
 </div>
 {{ end }}


### PR DESCRIPTION
### Fix description

Currently the social icons are still displayed, even if the option `params.socials.enabled` is set to `false`.
It currently only disables the `callToAction` text.

This change makes the icons also not show up at all if the option is not set to `true`.